### PR TITLE
add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,51 @@
+FROM python:3.9.13
+
+# Copy default endpoint specific user settings overrides into container to specify Python path
+COPY .devcontainer/settings.vscode.json /root/.vscode-remote/data/Machine/settings.json
+
+# Install pylint
+RUN pip install --upgrade pip && \
+    pip install pylint
+
+# Install git, process tools
+RUN apt-get update && apt-get -y install git procps
+
+# Install OpenJDK-11
+RUN apt-get update && \
+    apt-get install -y openjdk-11-jdk && \
+    apt-get install -y ant && \
+    apt-get clean;
+
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+RUN export JAVA_HOME
+
+# Install any missing dependencies for enhanced language service
+RUN apt-get install -y libicu[0-9][0-9]
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+# Add starship
+RUN apt install -y curl
+RUN curl -o install.sh -fsSL https://starship.rs/install.sh
+RUN chmod +x install.sh
+RUN ./install.sh -y
+RUN printf 'eval "$(starship init bash)"' >> '/root/.bashrc'
+RUN rm install.sh
+
+# Add editor setting
+RUN apt install -y nano
+RUN printf 'EDITOR=nano' >> '/root/.bashrc'
+
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add path for pytest
+ENV PYTHONPATH /workspaces/config-driven-data-pipeline/src
+
+# Add env variable for pyspark
+ENV PYSPARK_PYTHON python3.9

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "PySpark Sample",
+	"dockerFile": "Dockerfile",
+	"context": "..",
+	"extensions": [
+		"ms-python.python",
+		"njpwerner.autodocstring"
+	],
+	"onCreateCommand": "pip install -r ./requirements_dev.txt"
+}

--- a/.devcontainer/settings.vscode.json
+++ b/.devcontainer/settings.vscode.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python"
+}


### PR DESCRIPTION
Add devcontainer support for the sample. In .devcontainer folder there are 3 files:

- devcontainer.json: devcontainer configuration file
- Dockerfile: defines the devcontainer with needed os, libs and paths
- settings.vsconde.json: configuration file for Visual Studio Code

NOTE: may need add instructions into the README.md about how to use devcontainer.