### PR TITLE
Adding the missing parameter to the run_pipeline in _init_.py

### DIFF
--- a/src/cddp/__init__.py
+++ b/src/cddp/__init__.py
@@ -270,7 +270,7 @@ def entrypoint():
     if 'spark' not in globals():
         spark = create_spark_session()
 
-    run_pipeline(config_path, working_dir, stage_arg, task_arg, show_result, build_landing_zone, awaitTermination, cleanup_database)
+    run_pipeline(spark, config_path, working_dir, stage_arg, task_arg, show_result, build_landing_zone, awaitTermination, cleanup_database)
     
 
 def run_pipeline(spark, config_path, working_dir, stage_arg, task_arg, show_result, build_landing_zone, awaitTermination, cleanup_database):


### PR DESCRIPTION
**PR purpose:** 
Add the missing parameter of run_pipeline () in _init_.py

**How to verify the fix:**
Before the fix, on the dev branch, run the command for test purpose, 
`python src/main.py --config-path ./example/pipeline_fruit_batch.json --working-dir ./tmp --show-result True --build-landing-zone True --cleanup-database True`, and you will get the error pop up

```
  File "/workspaces/config-driven-data-pipeline/src/cddp/__init__.py", line 273, in entrypoint
    run_pipeline(config_path, working_dir, stage_arg, task_arg, show_result, build_landing_zone, awaitTermination, cleanup_database)
TypeError: run_pipeline() missing 1 required positional argument: 'cleanup_database'
```

After the fix, run the command `python src/main.py --config-path ./example/pipeline_fruit_batch.json --working-dir ./tmp --show-result True --build-landing-zone True --cleanup-database True`, and you will see the pipeline be running without the previous error. 

#23 