### PR TITLE
fix: update mermaid related CDN urls

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -927,8 +927,8 @@
         integrity="sha512-odNmoc1XJy5x1TMVMdC7EMs3IVdItLPlCeL5vSUPN2llYKMJ2eByTTAIiiuqLg+GdNr9hF6z81p27DArRFKT7A=="
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
-    <script src="https://unpkg.com/vue-mermaid-string"></script>
+    <script src="https://unpkg.com/mermaid@9/dist/mermaid.min.js"></script>
+    <script src="https://unpkg.com/vue-mermaid-string@3"></script>
     <script src="index.js"></script>
 </body>
 


### PR DESCRIPTION
Major updates of this PR:
- Added explicit version (@9) to **mermaid** CDN URL, since the current default latest version is v10, which has no mermaid.min.js file anymore, therefore old CDN URL returns 404 error.
- Also added explicit version (@3) to _vue-mermaid-string_ CDN URL, since the current default latest version is v4, which requires v3 Vue, but we're using v2 for now, therefore there's compatibility issue before adding the explicit version.

Now it works well again : )
![image](https://user-images.githubusercontent.com/17846095/226783159-96c3f193-e84f-432b-8bda-7d4e465861a3.png)
